### PR TITLE
revamp history page UI

### DIFF
--- a/project/front-end/src/scenes/qnsHistPage/QnsHistPage.tsx
+++ b/project/front-end/src/scenes/qnsHistPage/QnsHistPage.tsx
@@ -155,11 +155,11 @@ const QnsHistPage = () => {
     },
     {
       field: "completed",
-      headerName: "",
+      headerName: "Completed?",
       sortable: false,
       hideable: false,
       disableColumnMenu: true,
-      width: 70,
+      width: 100,
       renderCell: (params) => {
         return params.row.isCompleted ? (
           <CheckCircleOutlineIcon />
@@ -199,8 +199,8 @@ const QnsHistPage = () => {
             fontFamily={"Trebuchet MS"}
             sx={{ ...DisplayTextCSS }}
           >
-            Track your learning progress by matching with a peer{"\n"}and
-            attempting a question today!
+            Track your learning progress by matching with a peer and attempting
+            a question today!
           </Typography>
         </Box>
       </>
@@ -231,13 +231,24 @@ const QnsHistPage = () => {
               series={[
                 {
                   data: [
-                    { id: 0, value: difficultyCounts["Easy"], label: "Easy" },
+                    {
+                      id: 0,
+                      value: difficultyCounts["Easy"],
+                      label: "Easy",
+                      color: "#20df80",
+                    },
                     {
                       id: 1,
                       value: difficultyCounts["Medium"],
                       label: "Medium",
+                      color: "#f7b604fb",
                     },
-                    { id: 2, value: difficultyCounts["Hard"], label: "Hard" },
+                    {
+                      id: 2,
+                      value: difficultyCounts["Hard"],
+                      label: "Hard",
+                      color: "#f61602",
+                    },
                   ],
                 },
               ]}

--- a/project/front-end/src/scenes/qnsHistPage/QnsHistPage.tsx
+++ b/project/front-end/src/scenes/qnsHistPage/QnsHistPage.tsx
@@ -8,13 +8,22 @@ import { State } from "../../state";
 import { getSingleQuestion } from "../../api/questionAPI/getSingleQuestion";
 import { Question, QuestionHistory } from "../../state/question";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import NavBar from "../navBar";
 import "../widgets/MyQuestionWidget.css";
-import {DisplayDescription} from "../widgets/DisplayQuestionInformation";
-import { Box, useTheme } from "@mui/material";
+import { DisplayDescription } from "../widgets/DisplayQuestionInformation";
+import {
+  Box,
+  Button,
+  Typography,
+  useTheme,
+  useMediaQuery,
+} from "@mui/material";
 import { Theme } from "@mui/system";
 import { PieChart } from "@mui/x-charts/PieChart";
 import WidgetWrapper from "../../components/WidgetWrapper";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import Tooltip from "@mui/material/Tooltip";
 
 const convertDateTime = (date: string, time: string) => {
   const [day, month, year] = date.split("-").map(Number);
@@ -34,6 +43,18 @@ const countDifficulty = (questionData: QuestionHistory[]) => {
 
 const QnsHistPage = () => {
   const theme: Theme = useTheme();
+  const primaryLight = theme.palette.primary.light;
+  const primaryDark = theme.palette.primary.dark;
+  const DisplayTextCSS = {
+    backgroundImage:
+      theme.palette.mode === "dark"
+        ? `linear-gradient(45deg, ${primaryLight}, #fa57e2)`
+        : `linear-gradient(45deg, ${primaryDark}, #5d00fc)`,
+    backgroundClip: "text",
+    WebkitTextFillColor: "transparent",
+    mb: "1.5rem",
+  };
+  const isNonMobileScreens = useMediaQuery("(min-width:1000px)");
   const user = useSelector((state: State) => state.user);
   const token = useSelector((state: State) => state.token);
   const [questionHistory, setQuestionHistory] = useState<QuestionHistory[]>([]);
@@ -89,7 +110,6 @@ const QnsHistPage = () => {
       );
       setQuestionHistory(updatedQuestionHistory);
     }
-
     getQuestionHistory();
   }, []);
 
@@ -99,22 +119,109 @@ const QnsHistPage = () => {
     setOpenDescriptionPopup(true);
   };
 
+  const columns: GridColDef[] = [
+    {
+      field: "title",
+      headerName: "Title",
+      hideable: false,
+      width: 250,
+      renderCell: (params) => {
+        return (
+          <Tooltip title="Click to see more information" placement="bottom">
+            <Button sx={{ textTransform: "none" }}>{params.row.title}</Button>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      field: "difficulty",
+      headerName: "Difficulty",
+      hideable: false,
+      width: 120,
+    },
+    { field: "tags", headerName: "Tags", hideable: false, width: 120 },
+    {
+      field: "date",
+      headerName: "Attempted Date",
+      hideable: false,
+      width: 200,
+      valueFormatter: (params) => {
+        return new Date(params.value).toLocaleDateString("en-GB", {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+        });
+      },
+    },
+    {
+      field: "completed",
+      headerName: "",
+      sortable: false,
+      hideable: false,
+      disableColumnMenu: true,
+      width: 70,
+      renderCell: (params) => {
+        return params.row.isCompleted ? (
+          <CheckCircleOutlineIcon />
+        ) : (
+          <RadioButtonUncheckedIcon />
+        );
+      },
+    },
+  ];
+
+  const handleOnCellClick = (param: any) => {
+    if (param.field === "title") {
+      openDescriptionPopupWindow(param.row);
+    }
+  };
+
   const difficultyCounts = countDifficulty(questionHistory);
+
+  if (questionHistory.length == 0) {
+    return (
+      <>
+        <NavBar />
+        <Box
+          width="100%"
+          padding="2rem 6%"
+          display={isNonMobileScreens ? "flex" : "block"}
+          gap="0.5rem"
+          justifyContent="space-between"
+          flexDirection="column"
+          alignItems="center"
+          textAlign="center"
+        >
+          <Typography
+            fontWeight="bold"
+            variant="h5"
+            fontSize={"25px"}
+            fontFamily={"Trebuchet MS"}
+            sx={{ ...DisplayTextCSS }}
+          >
+            Track your learning progress by matching with a peer{"\n"}and
+            attempting a question today!
+          </Typography>
+        </Box>
+      </>
+    );
+  }
 
   return (
     <>
       <NavBar />
       <Box
         sx={
-          questionHistory.length > 1
+          Object.keys(difficultyCounts).length > 1
             ? {
                 display: "grid",
                 gridTemplateColumns: "1fr 3fr",
+                m: "1rem",
               }
-            : {}
+            : { m: "1rem" }
         }
       >
-        {questionHistory.length > 1 && (
+        {Object.keys(difficultyCounts).length > 1 && (
           <WidgetWrapper
             sx={{
               m: "1rem",
@@ -138,61 +245,34 @@ const QnsHistPage = () => {
             />
           </WidgetWrapper>
         )}
-
-        <Box
-          sx={{
-            m: "20px",
-            p: "1rem",
-            borderRadius: "24px",
-            backgroundColor: theme.palette.background.alt,
-          }}
-        >
+        <WidgetWrapper sx={{ width: "100%" }}>
           <div>
             <div className="questionTable">
-              <table className="questionTableList">
-                <thead>
-                  <tr>
-                    <th></th>
-                    <th>Title</th>
-                    <th>Difficulty</th>
-                    <th>Tags</th>
-                    <th>Date Attempted</th>
-                  </tr>
-                </thead>
-                {questionHistory.map((i) => {
-                  if (!i.title) return; // when question has been removed by admin
-
-                  return (
-                    <tbody>
-                      <tr>
-                        <td>{i.isCompleted && <CheckCircleOutlineIcon />}</td>
-                        <td onClick={() => openDescriptionPopupWindow(i)}>
-                          <div className="tooltip">
-                            {i.title}
-                            <span className="tooltiptext">
-                              Click to see more information
-                            </span>
-                          </div>
-                        </td>
-                        <td>{i.difficulty}</td>
-                        <td>{i.tags}</td>
-                        <td>{i.date.toLocaleDateString()}</td>
-                        <DisplayDescription
-                          open={openDescriptionPopup}
-                          onClose={() => {
-                            setOpenDescriptionPopup(false);
-                            setSelectedQuestion(NoQuestionSelected);
-                          }}
-                          question={selectedQuestion!}
-                        />
-                      </tr>
-                    </tbody>
-                  );
-                })}
-              </table>
+              <DataGrid
+                rows={questionHistory}
+                columns={columns}
+                getRowId={(row: any) =>
+                  row.title + row.difficulty + row.tags + row.date
+                }
+                onCellClick={handleOnCellClick}
+                initialState={{
+                  pagination: {
+                    paginationModel: { page: 0, pageSize: 10 },
+                  },
+                }}
+                pageSizeOptions={[10, 20]}
+              />
             </div>
           </div>
-        </Box>
+          <DisplayDescription
+            open={openDescriptionPopup}
+            onClose={() => {
+              setOpenDescriptionPopup(false);
+              setSelectedQuestion(NoQuestionSelected);
+            }}
+            question={selectedQuestion!}
+          />
+        </WidgetWrapper>
       </Box>
     </>
   );


### PR DESCRIPTION
* added text to tell users to attempt a question instead of showing an empty table if they have not attempted any questions
![Screenshot 2023-11-10 at 6 58 16 PM](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g27/assets/97357632/b10452af-cb43-43b5-955a-78cdfd146336)
* fixed bug that shows the piechart if user does more than 1 question
![Screenshot 2023-11-10 at 7 00 04 PM](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g27/assets/97357632/dc3c3c9f-7eac-4e4a-8b37-dbdfa5922a70)
* used the same UI for the table in question page
![Screenshot 2023-11-10 at 7 01 07 PM](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g27/assets/97357632/b5142db9-1323-4229-8f8d-054dcf5c0d76)
